### PR TITLE
Add backend tests and test script

### DIFF
--- a/backend/build.mjs
+++ b/backend/build.mjs
@@ -1,0 +1,36 @@
+import { readdir, readFile, writeFile, mkdir } from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+
+const nodeDir = dirname(process.execPath);
+const tsPath = resolve(nodeDir, '..', 'lib', 'node_modules', 'typescript', 'lib', 'typescript.js');
+const ts = await import(tsPath);
+
+async function getFiles(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = await Promise.all(entries.map(async (entry) => {
+    const res = path.join(dir, entry.name);
+    return entry.isDirectory() ? await getFiles(res) : res;
+  }));
+  return files.flat();
+}
+
+const srcFiles = await getFiles('src');
+const testFiles = await getFiles('test');
+const allFiles = srcFiles.concat(testFiles).filter((f) => f.endsWith('.ts'));
+
+for (const file of allFiles) {
+  const source = await readFile(file, 'utf8');
+  const { outputText } = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ESNext,
+      esModuleInterop: true,
+    },
+    fileName: file,
+  });
+  const outPath = path.join('dist', file.replace(/\.ts$/, '.js'));
+  await mkdir(path.dirname(outPath), { recursive: true });
+  await writeFile(outPath, outputText);
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -3,6 +3,10 @@
   "module": "index.ts",
   "type": "module",
   "private": true,
+  "scripts": {
+    "build": "node build.mjs",
+    "test": "npm run build && node --test \"dist/test/**/*.js\""
+  },
   "devDependencies": {
     "@types/bun": "latest",
     "@types/express": "^5.0.2"

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -26,8 +26,11 @@ app.use("/containers", containerRoutes);
 app.use("/chat", chatRoutes);
 
 const PORT = process.env.PORT || 4000;
-app.listen(PORT, () => {
-  console.log(`Docker Container API running on port ${PORT}`);
-});
+
+if (process.env.NODE_ENV !== "test") {
+  app.listen(PORT, () => {
+    console.log(`Docker Container API running on port ${PORT}`);
+  });
+}
 
 export default app;

--- a/backend/test/chat.test.ts
+++ b/backend/test/chat.test.ts
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+process.env.NODE_ENV = 'test';
+const { default: app } = await import('../src/index.js');
+
+function getPort(server: any): number {
+  const address = server.address();
+  if (typeof address === 'string' || !address) {
+    throw new Error('Invalid server address');
+  }
+  return address.port;
+}
+
+test('GET /chat/:id/messages returns session data', async (t) => {
+  const server = app.listen(0);
+  t.after(() => server.close());
+  const port = getPort(server);
+
+  const response = await fetch(`http://localhost:${port}/chat/test/messages`);
+  const body = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.equal(body.success, true);
+  assert.ok(Array.isArray(body.messages));
+  assert.equal(typeof body.sessionId, 'string');
+});

--- a/backend/test/docker.test.ts
+++ b/backend/test/docker.test.ts
@@ -1,0 +1,8 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { getDockerfile } from '../src/services/docker.js';
+
+test('getDockerfile reads Dockerfile content', async () => {
+  const content = await getDockerfile();
+  assert.ok(content.includes('FROM node:18-alpine'));
+});


### PR DESCRIPTION
## Summary
- add build and test scripts to backend package
- prevent server from starting during tests
- create basic chat route and docker service tests

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_689ddfdc3974832fa26bc051164795d0